### PR TITLE
Adicion de feature fecha a plantilla, correccion de algunos errores

### DIFF
--- a/Code/View/webScraping.py
+++ b/Code/View/webScraping.py
@@ -113,7 +113,7 @@ def add_template_path(filename):
 
 
 def main():
-
+  
   main_list = MessageList("Resumen:")
   msg_list = MessageList()
 

--- a/Functions/cas.py
+++ b/Functions/cas.py
@@ -142,7 +142,7 @@ def get_rango_fechas(src):
 def get_publicacion_en(src):
     regex = "publicacion en [^:]*:\s+([^\.|,|\\n|\\r]*)"
     date_str = get_match_group(src, regex)
-
+    
     if date_str is None:
         return None
     date = get_month_year(date_str)

--- a/Templates/aptitus.txt
+++ b/Templates/aptitus.txt
@@ -9,6 +9,7 @@ Number of Offers Source:    |1 section\{"class":"grid_search_results"}\->1 h1\{}
 Links per Page:             |20|
 Number of Sources:          |1|
 Offer Sources & Date:       |* a\{"class":"jobs_ads"}\href->1 div\{"class":"jobs_ads_options"}\->1 span\{}\|
+Date Feature:               |optional|
 First Level Features:       |0|
 
 Offer Structure:

--- a/Templates/bumeran.txt
+++ b/Templates/bumeran.txt
@@ -9,6 +9,7 @@ Number of Offers Source:    |1 div\{"class":"letra-chica"}\->1 strong\{}\|
 Links per Page:             |15|
 Number of Sources:          |1|
 Offer Sources & Date:       |* a\{"class":"aviso_box"}\href->1 h3\{"class":"aviso_cuando"}\|
+Date Feature:               |optional|
 First Level Features:       |0|
 
 Offer Structure:

--- a/Templates/cas.txt
+++ b/Templates/cas.txt
@@ -18,6 +18,7 @@ Number of Offers Source:    |optional|
 Links per Page:             |optional|
 Number of Sources:          |1|
 Offer Source:               |* li\{"id":"demo"}\->4 div\{}\->1 a\{}\href|
+Date Feature:               |descripción|
 First Level Features:       |1|
 #
 # Es necesario especificar cada feature de primer nivel por su cuenta (Un par Feature Name, Feature Values)
@@ -31,8 +32,8 @@ Feature Values:             |* li\{"id":"demo"}\->3 div\{}\->1 p\{}\|
 Offer Structure:
 ID_features:                |['ubicación', 'descripción', 'empresa', 'título']
 Feature Names:              |["descripción"]|
-Feature Values:             |1 div\{"id":"texto3"}\|
+Feature Values:             |* div\{"id":"texto3"}\|
 Feature Names:              |["empresa"]|
-Feature Values:             |1 div\{"id":"principal"}\->1 div\{"id":"texto1s"}\->1 p\{}\->1 b\{}\|
+Feature Values:             |* div\{"id":"principal"}\->1 div\{"id":"texto1s"}\->1 p\{}\->1 b\{}\|
 Feature Names:              |["título"]|
-Feature Values:             |1 div\{"id":"textoTitulo"}\->1 p\{}\->1 b\{}\|
+Feature Values:             |* div\{"id":"textoTitulo"}\->1 p\{}\->1 b\{}\|

--- a/Templates/example.txt
+++ b/Templates/example.txt
@@ -89,9 +89,14 @@ Links per Page:             |optional|
 # 
 Number of Sources:          |1|
 # 
-# Estructuras donde encontrar las convocatorias
+# Estructuras donde encontrar las convocatorias (deben coincidir con el Number of Sources)
 # 
 Offer Sources:              |* a\{"class":"jobs_ads"}\href->1 div\{"class":"jobs_ads_options"}\->1 span\{}\|
+#
+# Feature a partir del cual obtener la fecha de publicación si no se encuentra definida en alguna de las estructuras 
+# previamente especificadas. Dato tipo texto
+#
+Date Feature:               |optional|
 # 
 # Número de features en primer nivel (antes de entrar a la página
 # de la convocatoria)

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,6 +4,7 @@ cassandra-driver==3.7.1
 dateparser==0.5.0
 Django==1.10.3
 jdatetime==1.8.1
+lxml==3.6.4
 nltk==3.2.1
 odfpy==1.3.3
 pyexcel-io==0.2.3


### PR DESCRIPTION
Se añadió la especificación del feature del cual obtener la fecha de publicación en caso no se encuentre en las estructuras definidas por `Offer Sources`.

Se corrigieron algunos errores en la plantilla `cas.txt`: 
Los `Feature Values` deben devolver una lista, pero en la plantilla solo se devolvía una cadena, por lo que no se obtenían los valores correctos para la oferta.

Adición de un atributo `limit` para `get_offers_from_page_url()` para limitar el número de ofertas a procesar. Más que nada para propósito de testing.

Corrección de los requerimientos de `pip`:
Faltaba `lxml`, utilizada por `BeautifulSoup`